### PR TITLE
Use boost::gregorian and boost::posix_time

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -22,31 +22,6 @@
 namespace score {
 namespace ast {
 
-struct Time {
-  // TODO: support time-zones!
-  Time() = default;
-  Time(unsigned char h, unsigned char m, unsigned char s, unsigned long ss)
-      : hour(h), minute(m), second(s), subsecond(ss) {}
-  unsigned char hour;
-  unsigned char minute;
-  unsigned char second;
-  unsigned long subsecond;
-
-  static Time makeTime(unsigned char h, unsigned char m,
-                       const boost::optional<unsigned char> &os,
-                       const boost::optional<unsigned long> &oss) {
-    return Time(h, m, boost::get_optional_value_or(os, 0),
-                boost::get_optional_value_or(oss, 0));
-  }
-};
-
-// struct Datetime {
-//   Datetime() = default;
-//   Datetime(const Date &d, const Time &t) : date(d), time(t) {}
-//   Date date;
-//   Time time;
-// };
-
 // TODO
 // struct Period {
 // };
@@ -88,7 +63,7 @@ using Expr = boost::variant<
                   // constructible
     double,       // TODO: not exact/arb precision - will improve later
     std::string,
-    boost::gregorian::date, Time, // Datetime, // Period,
+    boost::gregorian::date, boost::posix_time::time_duration, boost::posix_time::ptime, // Period,
     boost::recursive_wrapper<Variable>, boost::recursive_wrapper<Exists>,
 
     boost::recursive_wrapper<UnaryOp<OpUnaryMinus>>,
@@ -226,9 +201,3 @@ BOOST_FUSION_ADAPT_STRUCT(score::ast::Variable,
                            scope)(std::vector<score::ast::Qualifier>, quals))
 BOOST_FUSION_ADAPT_STRUCT(score::ast::Exists,
                           (score::ast::Qualifier, qualifier))
-
-BOOST_FUSION_ADAPT_STRUCT(score::ast::Time,
-                          (unsigned char, hour)(unsigned char, minute)(
-                              unsigned char, second)(unsigned long, subsecond))
-// BOOST_FUSION_ADAPT_STRUCT(score::ast::Datetime,
-//                           (score::ast::Date, date)(score::ast::Time, time))

--- a/src/ast.h
+++ b/src/ast.h
@@ -9,6 +9,8 @@
 
 #include <boost/optional.hpp>
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 #include <boost/fusion/include/adapt_struct.hpp>
 
 #include <boost/variant/recursive_wrapper.hpp>
@@ -19,15 +21,6 @@
 
 namespace score {
 namespace ast {
-
-struct Date {
-  Date() = default;
-  Date(unsigned short y, unsigned char m, unsigned char d)
-      : year(y), month(m), day(d) {}
-  unsigned short year;
-  unsigned char month;
-  unsigned char day;
-};
 
 struct Time {
   // TODO: support time-zones!
@@ -47,12 +40,12 @@ struct Time {
   }
 };
 
-struct Datetime {
-  Datetime() = default;
-  Datetime(const Date &d, const Time &t) : date(d), time(t) {}
-  Date date;
-  Time time;
-};
+// struct Datetime {
+//   Datetime() = default;
+//   Datetime(const Date &d, const Time &t) : date(d), time(t) {}
+//   Date date;
+//   Time time;
+// };
 
 // TODO
 // struct Period {
@@ -94,7 +87,8 @@ using Expr = boost::variant<
     unsigned int, // list these first since first field needs to be default
                   // constructible
     double,       // TODO: not exact/arb precision - will improve later
-    std::string, Date, Time, Datetime, // Period,
+    std::string,
+    boost::gregorian::date, Time, // Datetime, // Period,
     boost::recursive_wrapper<Variable>, boost::recursive_wrapper<Exists>,
 
     boost::recursive_wrapper<UnaryOp<OpUnaryMinus>>,
@@ -233,11 +227,8 @@ BOOST_FUSION_ADAPT_STRUCT(score::ast::Variable,
 BOOST_FUSION_ADAPT_STRUCT(score::ast::Exists,
                           (score::ast::Qualifier, qualifier))
 
-BOOST_FUSION_ADAPT_STRUCT(score::ast::Date,
-                          (unsigned short, year)(unsigned char,
-                                                 month)(unsigned char, day))
 BOOST_FUSION_ADAPT_STRUCT(score::ast::Time,
                           (unsigned char, hour)(unsigned char, minute)(
                               unsigned char, second)(unsigned long, subsecond))
-BOOST_FUSION_ADAPT_STRUCT(score::ast::Datetime,
-                          (score::ast::Date, date)(score::ast::Time, time))
+// BOOST_FUSION_ADAPT_STRUCT(score::ast::Datetime,
+//                           (score::ast::Date, date)(score::ast::Time, time))

--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -15,6 +15,8 @@ template <typename Iterator>
 struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
   Grammar() : Grammar::base_type(statementRule) {
     using namespace qi;
+    using namespace boost::gregorian;
+    using namespace boost::posix_time;
 
     statementRule = exprRule.alias() >> eoi;
 
@@ -54,7 +56,7 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
       | simpleRule            [_val = _1];
     simpleRule
       %= lit('(') >> exprRule >> lit(')')
-      |  lit('#') >> datetimeRule >> lit('#')
+      // |  lit('#') >> datetimeRule >> lit('#')
       |  lit('#') >> timeRule >> lit('#')
       |  lit('#') >> dateRule >> lit('#')
       |  double_ // TODO: allow negative numbers? replace with a parser for fixed-precision
@@ -71,7 +73,7 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
     varRule   = (-(string("$")|string("^")|string("in.")|string("out.")|string("this."))
                   >> ((qualRule % '.'))) [_val = phx::construct<ast::Variable>(_1, _2)];
 
-    datetimeRule %= dateRule >> timeRule;
+    // datetimeRule %= dateRule >> timeRule;
     dateRule     %= uint_parser<unsigned short, 10, 4, 4>()
                     >> lit('-') >> uint_parser<unsigned char, 10, 2, 2>()
                     >> lit('-') >> uint_parser<unsigned char, 10, 2, 2>();
@@ -100,7 +102,7 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
     BOOST_SPIRIT_DEBUG_NODE(existsRule);
     BOOST_SPIRIT_DEBUG_NODE(varRule);
 
-    BOOST_SPIRIT_DEBUG_NODE(datetimeRule);
+    // BOOST_SPIRIT_DEBUG_NODE(datetimeRule);
     BOOST_SPIRIT_DEBUG_NODE(timeRule);
     BOOST_SPIRIT_DEBUG_NODE(dateRule);
 
@@ -126,9 +128,9 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
                                                           existsRule,
                                                           varRule;
 
-  qi::rule<Iterator, ast::Date(),      ascii::space_type> dateRule;
-  qi::rule<Iterator, ast::Time(),      ascii::space_type> timeRule;
-  qi::rule<Iterator, ast::Datetime(),  ascii::space_type> datetimeRule;
+  qi::rule<Iterator, ast::Time(),              ascii::space_type> timeRule;
+  qi::rule<Iterator, boost::gregorian::date(), ascii::space_type> dateRule;
+  // qi::rule<Iterator, ast::Datetime(),       ascii::space_type> datetimeRule;
 
   qi::rule<Iterator, ast::Predicate(), ascii::space_type> predRule;
   qi::rule<Iterator, ast::Qualifier(), ascii::space_type> qualRule;

--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -56,7 +56,7 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
       | simpleRule            [_val = _1];
     simpleRule
       %= lit('(') >> exprRule >> lit(')')
-      // |  lit('#') >> datetimeRule >> lit('#')
+      |  lit('#') >> datetimeRule >> lit('#')
       |  lit('#') >> timeRule >> lit('#')
       |  lit('#') >> dateRule >> lit('#')
       |  double_ // TODO: allow negative numbers? replace with a parser for fixed-precision
@@ -73,14 +73,18 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
     varRule   = (-(string("$")|string("^")|string("in.")|string("out.")|string("this."))
                   >> ((qualRule % '.'))) [_val = phx::construct<ast::Variable>(_1, _2)];
 
-    // datetimeRule %= dateRule >> timeRule;
+    datetimeRule %= dateRule >> timeRule;
     dateRule     %= uint_parser<unsigned short, 10, 4, 4>()
                     >> lit('-') >> uint_parser<unsigned char, 10, 2, 2>()
                     >> lit('-') >> uint_parser<unsigned char, 10, 2, 2>();
-    timeRule      = (lit('T') >> uint_parser<unsigned short, 10, 2, 2>()
-                      >> lit(':') >> uint_parser<unsigned char, 10, 2, 2>()
-                      >> -(lit(':') >> uint_parser<unsigned char, 10, 2, 2>())
-                      >> -(lit('.') >> ulong_)) [_val = phx::bind(&score::ast::Time::makeTime, _1, _2, _3, _4)];
+    timeRule      =      (lit('T') >> uint_parser<unsigned short, 10, 2, 2>())
+                         [_val += phx::construct<hours>(_1)]
+                      >> (lit(':') >> uint_parser<unsigned char, 10, 2, 2>())
+                         [_val += phx::construct<minutes>(_1)]
+                      >> -(lit(':') >> uint_parser<unsigned char, 10, 2, 2>()
+                          [_val += phx::construct<seconds>(_1)])
+                      >> -(lit('.') >> ulong_
+                          [_val += phx::construct<milliseconds>(_1)]);
 
     idRule = alpha >> *(alnum | char_('_'));
 
@@ -102,7 +106,7 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
     BOOST_SPIRIT_DEBUG_NODE(existsRule);
     BOOST_SPIRIT_DEBUG_NODE(varRule);
 
-    // BOOST_SPIRIT_DEBUG_NODE(datetimeRule);
+    BOOST_SPIRIT_DEBUG_NODE(datetimeRule);
     BOOST_SPIRIT_DEBUG_NODE(timeRule);
     BOOST_SPIRIT_DEBUG_NODE(dateRule);
 
@@ -128,9 +132,9 @@ struct Grammar : qi::grammar<Iterator, ast::Statement(), ascii::space_type> {
                                                           existsRule,
                                                           varRule;
 
-  qi::rule<Iterator, ast::Time(),              ascii::space_type> timeRule;
-  qi::rule<Iterator, boost::gregorian::date(), ascii::space_type> dateRule;
-  // qi::rule<Iterator, ast::Datetime(),       ascii::space_type> datetimeRule;
+  qi::rule<Iterator, boost::posix_time::time_duration(), ascii::space_type> timeRule;
+  qi::rule<Iterator, boost::gregorian::date(),           ascii::space_type> dateRule;
+  qi::rule<Iterator, boost::posix_time::ptime(),         ascii::space_type> datetimeRule;
 
   qi::rule<Iterator, ast::Predicate(), ascii::space_type> predRule;
   qi::rule<Iterator, ast::Qualifier(), ascii::space_type> qualRule;


### PR DESCRIPTION
Replaces custom `Date`, `Time`, and `Datetime` classes with `boost::Date_Time` classes `boost::gregorian::date`, `boost::posix_time::time_duration`, and `boost::posix_time::ptime`, respectively.

Based on #2.